### PR TITLE
CITZEDC824 - Replace 'notes' with 'description

### DIFF
--- a/ckanext/bcgov/templates/package/snippets/package_form.html
+++ b/ckanext/bcgov/templates/package/snippets/package_form.html
@@ -50,6 +50,12 @@ then itself be extended to add/remove blocks of functionality. #}
         			{% endif %}
         		{% else %}
         			{% set len1 = error_list|length %}
+
+                    {# CITZEDC824 - Rename notes to description when the decription box is empty #}
+                    {% if key == "notes" %}
+                        {% set key = "description" %}
+                    {% endif %}
+
         			<li date-field-label="{{ key }}"> {{ key }} :
         			{% for err_val in error_list %}
         				{{ err_val }}


### PR DESCRIPTION
Changed the template to replace the value 'notes' with 'description' in
the the invalid form error message.
